### PR TITLE
Allow connector to be passed to Query.add_q() so that Q objects can b…

### DIFF
--- a/search/ql.py
+++ b/search/ql.py
@@ -180,7 +180,7 @@ class Q(object):
         obj.add(other)
         obj.conn = conn
         return obj
-    
+
     def add(self, child):
         self.children.append(child)
 
@@ -235,14 +235,19 @@ class Query(object):
 
         return new_q
 
-    def add_q(self, q):
+    def add_q(self, q, conn=None):
         """Add a `Q` object to the internal reduction of gathered Qs,
         effectively adding a filter clause to the querystring.
         """
         if self._gathered_q is None:
             self._gathered_q = q
             return self
-        conn = self._gathered_q.DEFAULT.lower()
+
+        if not conn:
+            conn = self._gathered_q.DEFAULT
+
+        conn = conn.lower()
+
         self._gathered_q = getattr(self._gathered_q, '__%s__' % conn)(q)
         return self
 

--- a/search/tests/test_ql.py
+++ b/search/tests/test_ql.py
@@ -12,7 +12,7 @@ class FakeDocument(DocumentModel):
 
 
 class FakeGeoDocument(DocumentModel):
-    my_loc = GeoField()    
+    my_loc = GeoField()
 
 
 class TestKeywordQuery(unittest.TestCase):
@@ -34,6 +34,21 @@ class TestQuery(unittest.TestCase):
             u"(foo > 42)",
             unicode(query))
 
+    def test_add_q_or(self):
+        """Test that two Q objects can be added to a query without needing to wrap them in
+        another Q object
+        """
+        query = Query(FakeDocument)
+
+        q_1 = Q(foo=42)
+        q_2 = Q(foo=128)
+
+        query.add_q(q_1)
+        query.add_q(q_2, conn=Q.OR)
+
+        self.assertEqual(
+            u'((foo:"42") OR (foo:"128"))',
+            unicode(query))
 
 class TestGeoQuery(unittest.TestCase):
 


### PR DESCRIPTION
…e ORed together onto an existing query without needing to wrap them in a parent