### PR TITLE
MapReduce tasks

### DIFF
--- a/search/django/tasks.py
+++ b/search/django/tasks.py
@@ -23,9 +23,15 @@ logger = logging.getLogger(__name__)
 
 
 def get_deferred_target():
-    """Return the name of an App Engine module for running a deferred task."""
-    current_module = modules.get_current_version_name()
-    target = getattr(settings, 'WORKER_MODULE_NAME', current_module)
+    """Return the name of an App Engine module or version for running a
+    deferred task.
+    """
+    settings_key = 'WORKER_MODULE_NAME'
+
+    if hasattr(settings, settings_key):
+        target = getattr(settings, settings_key)
+    else:
+        target = modules.get_current_version_name()
 
     return target
 

--- a/search/django/tasks.py
+++ b/search/django/tasks.py
@@ -31,7 +31,12 @@ def get_deferred_target():
 
 
 class ReindexMapReduceTask(MapReduceTask):
-    target = property(get_deferred_target)
+    @property
+    def target(self):
+        # Wrapped in a property so it doesn't get called when this module is
+        # imported (because the modules API will raise KeyError if called too
+        # early).
+        return get_deferred_target()
 
     @staticmethod
     def map(instance, *args, **kwargs):


### PR DESCRIPTION
Hi,

These changes fix part of the problems reported in #51 .

Specifically, fixed the `TypeError: get_deferred_target() takes no arguments (1 given)` exception, and also changed the target helper function so it only does an API call when the Django setting is missing.

I still get the `PipelineSetupError` exception when running locally, but it works when deployed to App Engine.

I ran tests, and there are 2 tests that fail. They also fail in master.

```
======================================================================
FAIL: test_metaclass_side_effects (search.django.tests.test_definition.TestSearchableMeta)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/dbuxton/Documents/Development/search/search/django/tests/test_definition.py", line 155, in test_metaclass_side_effects
    self.assertEqual(len(unindex_receivers), 1)
AssertionError: 0 != 1

======================================================================
FAIL: test_decorator_side_effects (search.django.tests.test_definition.TestSearchable)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/dbuxton/Documents/Development/search/search/django/tests/test_definition.py", line 41, in test_decorator_side_effects
    self.assertEqual(len(unindex_receivers), 1)
AssertionError: 0 != 1

```


David B.
