### PR TITLE
Fix none queryset handling

### DIFF
--- a/search/django/adapters.py
+++ b/search/django/adapters.py
@@ -35,13 +35,22 @@ class SearchQueryAdapter(object):
         if isinstance(queryset, cls):
             return queryset
 
-        filters = cls.get_filters_from_queryset(queryset)
+        filters = (
+            {} if queryset.query.is_empty() else
+            cls.get_filters_from_queryset(queryset)
+        )
         search_query = cls.filters_to_search_query(
             filters,
             queryset.model,
             ids_only=ids_only
         )
-        return cls(search_query, queryset=queryset, ids_only=ids_only)
+
+        return cls(
+            search_query,
+            queryset=queryset,
+            ids_only=ids_only,
+            _is_none=queryset.query.is_empty()
+        )
 
     @classmethod
     def filters_to_search_query(cls, filters, model, query=None, ids_only=False):
@@ -51,6 +60,10 @@ class SearchQueryAdapter(object):
         from .utils import get_search_query
 
         search_query = query or get_search_query(model, ids_only=ids_only)
+
+        if not filters:
+            return search_query
+
         connector = filters['connector']
         children = filters['children']
 

--- a/search/django/rest_framework/mixins.py
+++ b/search/django/rest_framework/mixins.py
@@ -63,7 +63,7 @@ class SearchMixin(object):
             # There was an exception trying to parse the query string. Rather
             # than logging the query to the user, pretend there were no results
             page = None
-            queryset = []
+            queryset = queryset.none()
 
         if self.is_searching():
             # patch the raw query onto the object for get_paginated_response to use

--- a/search/django/tests/test_search_adapter.py
+++ b/search/django/tests/test_search_adapter.py
@@ -88,3 +88,11 @@ class TestSearchQueryAdapter(TestCase):
         desc_qs = FooWithMeta.objects.order_by('-name')
         desc_search_qs = SearchQueryAdapter.from_queryset(asc_qs)
         self.assertSameList(desc_qs, desc_search_qs.as_model_objects(), ordered=True)
+
+    def test_none_queryset(self):
+        Foo.objects.create(name='David')
+        none_qs = Foo.objects.all().filter(name='David').none()
+        search_qs = SearchQueryAdapter.from_queryset(none_qs)
+        self.assertEqual(0, search_qs.count())
+
+


### PR DESCRIPTION
This PR fixed the search adapters handling of empty querysets, specifically a queryset returned from calling `none()`. 

Also fixes #61 