### PR TITLE
64 customize deadline

### DIFF
--- a/search/indexes.py
+++ b/search/indexes.py
@@ -247,7 +247,7 @@ class Index(object):
                 include_start_object=False
             )
 
-    def search(self, document_class=None, ids_only=False):
+    def search(self, document_class=None, ids_only=False, deadline=None):
         """Initialise the search query for this index and document class"""
         document_class = document_class or self.document_class
         if not document_class:
@@ -260,5 +260,6 @@ class Index(object):
         return SearchQuery(
             self._index,
             document_class=document_class,
-            ids_only=ids_only
+            ids_only=ids_only,
+            deadline=deadline,
         )


### PR DESCRIPTION
This PR adds support for customizing the default RPC deadline passed to the underlying search API which currently *appears* to default to 10 seconds, which can be kinda low for very large queries.

This can be set in two ways:

- Passing `deadline` as a keyword argument to the `Index` class constructor
- Via the `SEARCH_RPC_DEADLINE` setting in a Django project.

Fixes #64 